### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,5 @@
   "version_number": "0.0.10",
   "website_url": "https://github.com/weissi1994/LethalMod-ESP",
   "description": "ESP Mod with pathfinding capabilities",
-  "dependencies": ["BepInEx-BepInExPack-5.4.2100"]
+  "dependencies": ["BepInEx-BepInExPack-5.4.2100", "BepInEx_Unofficial-BepInEx_GraphicsSettings-1.3.1"]
 }


### PR DESCRIPTION
Fixes issue #5. Needs BepInEx_GraphicsSettings run at least once.  Can be disabled after initial launch, though not 100% certain this is the case. Steps to reproduce issue:
1. Create new mod profile.
2. Install mod.
3. Launch game and see that configuration is not present.
4. Install BepInEx_GraphicsSettings and relaunch game.
5. Configuration should now be seen in top left corner.